### PR TITLE
Bug fix: Iterations vs. warmup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,4 +4,4 @@
 
 * Priors for the structural parameter simplex can now be defined using `prior()` (#2).
 
-* Priors are now checked for compatibility with the specified model and Q-matrix (i.e., errors are thrown if the user specifies a prior for a class or parameter that is irrelevant to the defined model; #3).
+* Priors are now checked for compatibility with the specified model and Q-matrix (i.e., errors are thrown if the user specifies a prior for a class or parameter that is irrelevant to the defined model; #1).

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,3 +5,5 @@
 * Priors for the structural parameter simplex can now be defined using `prior()` (#2).
 
 * Priors are now checked for compatibility with the specified model and Q-matrix (i.e., errors are thrown if the user specifies a prior for a class or parameter that is irrelevant to the defined model; #1).
+
+* Fixed bug with `backend = "rstan"` where warmup iterations could be more than the total iterations requested by the user if warmup iterations were not also specified (#6).

--- a/R/stan-utils.R
+++ b/R/stan-utils.R
@@ -42,7 +42,10 @@ create_stan_params <- function(backend, method, ...) {
   ## some reasonable defaults
   if (method == "mcmc") {
     if (backend == "rstan") {
-      defl_pars <- list(iter = 4000, warmup = 2000, chains = 4,
+      defl_iter <- ifelse("iter" %in% user_names, user_pars$iter, 4000)
+      defl_warmup <- ifelse("warmup" %in% user_names, user_pars$warmup,
+                            defl_iter / 2)
+      defl_pars <- list(iter = defl_iter, warmup = defl_warmup, chains = 4,
                         cores = getOption("mc.cores", 1L))
     } else if (backend == "cmdstanr") {
       defl_pars <- list(iter_sampling = 2000, iter_warmup = 2000, chains = 4,


### PR DESCRIPTION
Fixes an edge case for `backend = "rstan"` where a user could specify a number of iterations using `iter`, but not specify `warmup`. In this case, `warmup` would default to 2000. However, if the specified `iter` was less than 2000, this would cause rstan to throw an error. Now, if only `iter` is specified, `warmup` defaults to `iter / 2`, as in `rstan::sampling()`.

This closes #6.