### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,6 +45,7 @@ jobs:
           extra-packages: |
             any::rcmdcheck
             github::stan-dev/cmdstanr
+          upgrade: true
           needs: check
 
       - name: Install cmdstan

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,8 +45,6 @@ jobs:
           extra-packages: |
             any::rcmdcheck
             github::stan-dev/cmdstanr
-            url::https://mc-stan.org/r-packages/src/contrib/rstan_2.26.22.tar.gz
-            url::https://mc-stan.org/r-packages/src/contrib/StanHeaders_2.26.22.tar.gz
           needs: check
 
       - name: Install cmdstan

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,7 +45,7 @@ jobs:
           extra-packages: |
             any::rcmdcheck
             github::stan-dev/cmdstanr
-          upgrade: TRUE
+          upgrade: 'TRUE'
           needs: check
 
       - name: Install cmdstan

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,7 +45,7 @@ jobs:
           extra-packages: |
             any::rcmdcheck
             github::stan-dev/cmdstanr
-          upgrade: true
+          upgrade: TRUE
           needs: check
 
       - name: Install cmdstan

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          cache-version: 2
+          cache-version: 3
           extra-packages: |
             any::rcmdcheck
             github::stan-dev/cmdstanr

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -30,7 +30,10 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, any::tidyverse, local::.
+          extra-packages: |
+            any::pkgdown
+            any::tidyverse
+            local::.
           needs: website
 
       - name: Build site

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -26,7 +26,7 @@ jobs:
           extra-packages: |
             any::covr
             github::stan-dev/cmdstanr
-          upgrade: true
+          upgrade: TRUE
           needs: coverage
 
       - name: Install cmdstan

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -26,7 +26,7 @@ jobs:
           extra-packages: |
             any::covr
             github::stan-dev/cmdstanr
-          upgrade: TRUE
+          upgrade: 'TRUE'
           needs: coverage
 
       - name: Install cmdstan

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -26,6 +26,7 @@ jobs:
           extra-packages: |
             any::covr
             github::stan-dev/cmdstanr
+          upgrade: true
           needs: coverage
 
       - name: Install cmdstan

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,8 +24,7 @@ jobs:
         with:
           extra-packages: |
             any::covr
-            url::https://mc-stan.org/r-packages/src/contrib/rstan_2.26.22.tar.gz
-            url::https://mc-stan.org/r-packages/src/contrib/StanHeaders_2.26.22.tar.gz
+            github::stan-dev/cmdstanr
           needs: coverage
 
       - name: Install cmdstan

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -22,6 +22,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          cache-version: 3
           extra-packages: |
             any::covr
             github::stan-dev/cmdstanr


### PR DESCRIPTION
The goal is to always pull the latest version of rstan and StanHeaders from mc-stan.org/r-packages, without having to specify as specific version using the "url::" syntax.