### PR TITLE
Update interaction constraints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # measr (development version)
 
+* Fixed bug in the LCDM specification of constraints for level-3 and above interaction terms.
+
 # measr 0.3.1
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/stan-lcdm.R
+++ b/R/stan-lcdm.R
@@ -39,11 +39,6 @@ lcdm_script <- function(qmatrix, prior = NULL, strc = "unconstrained",
       ),
       atts = gsub("[^0-9|_]", "", .data$parameter),
       comp_atts = one_down_params(.data$atts, item = .data$item_id),
-      num_comp = dplyr::case_when(
-        comp_atts == "" ~ 0,
-        TRUE ~ sapply(gregexpr(pattern = ",", text = .data$comp_atts),
-                      function(.x) length(attr(.x, "match.length"))) + 1
-      ),
       param_name = glue::glue("l{item_id}_{param_level}",
                               "{gsub(\"__\", \"\", atts)}"),
       constraint = dplyr::case_when(

--- a/R/stan-utils.R
+++ b/R/stan-utils.R
@@ -124,11 +124,25 @@ model_matrix_name_repair <- function(x) {
 one_down_params <- function(x, item) {
   all_atts <- strsplit(x, split = "__")[[1]]
   if (length(all_atts) <= 1) return("")
-  att_combos <- utils::combn(all_atts, m = length(all_atts) - 1,
-                             simplify = FALSE)
 
-  paste("l", item, "_", length(all_atts) - 1,
-        sapply(att_combos, paste, collapse = ""), sep = "", collapse = ",")
+  comps <- vector("list", length(all_atts))
+  for (att in seq_along(all_atts)) {
+    att_comp <- vector("character", length(all_atts) - 1)
+    for (level in seq_along(att_comp)) {
+      att_combos <- utils::combn(all_atts, m = level, simplify = FALSE)
+      att_combos <- att_combos[vapply(att_combos,
+                                      function(.x, att) {
+                                        any(.x == att)
+                                      },
+                                      logical(1), att = all_atts[att])]
+
+      att_comp[level] <- paste("l", item, "_", level,
+            sapply(att_combos, paste, collapse = ""), sep = "", collapse = "+")
+    }
+    comps[[att]] <- paste(att_comp, collapse = "+")
+  }
+
+  paste(comps, collapse = ",")
 }
 one_down_params <- Vectorize(one_down_params, USE.NAMES = FALSE)
 

--- a/tests/testthat/test-stan-utils.R
+++ b/tests/testthat/test-stan-utils.R
@@ -20,15 +20,29 @@ test_that("can identify component parameters", {
   expect_identical(one_down_params(x = "3__4", item = 6), "l6_13,l6_14")
   expect_identical(one_down_params(x = "9__10", item = 3), "l3_19,l3_110")
 
-  # three-way interactions have two-way interaction components
+  # three-way interactions have one- and two-way interaction components
   expect_identical(one_down_params(x = "1__2__3", item = 1),
-                   "l1_212,l1_213,l1_223")
+                   paste0("l1_11+l1_212+l1_213,",
+                          "l1_12+l1_212+l1_223,",
+                          "l1_13+l1_213+l1_223"))
   expect_identical(one_down_params(x = "5__9__12", item = 22),
-                   "l22_259,l22_2512,l22_2912")
+                   paste0("l22_15+l22_259+l22_2512,",
+                          "l22_19+l22_259+l22_2912,",
+                          "l22_112+l22_2512+l22_2912"))
 
-  # four-way interactions have three-way interaction components
+  # four-way interactions have one-, two-, and three-way interaction components
   expect_identical(one_down_params(x = "1__2__3__4", item = 1),
-                   "l1_3123,l1_3124,l1_3134,l1_3234")
-  expect_identical(one_down_params(x = "2__4__6__8", item = 13),
-                   "l13_3246,l13_3248,l13_3268,l13_3468")
+                   paste0(
+                     "l1_11+l1_212+l1_213+l1_214+l1_3123+l1_3124+l1_3134,",
+                     "l1_12+l1_212+l1_223+l1_224+l1_3123+l1_3124+l1_3234,",
+                     "l1_13+l1_213+l1_223+l1_234+l1_3123+l1_3134+l1_3234,",
+                     "l1_14+l1_214+l1_224+l1_234+l1_3124+l1_3134+l1_3234"
+                   ))
+  expect_identical(one_down_params(x = "2__4__6__8", item = 9),
+                   paste0(
+                     "l9_12+l9_224+l9_226+l9_228+l9_3246+l9_3248+l9_3268,",
+                     "l9_14+l9_224+l9_246+l9_248+l9_3246+l9_3248+l9_3468,",
+                     "l9_16+l9_226+l9_246+l9_268+l9_3246+l9_3268+l9_3468,",
+                     "l9_18+l9_228+l9_248+l9_268+l9_3248+l9_3268+l9_3468"
+                   ))
 })


### PR DESCRIPTION
Interactions are currently only constrained based on the model parameters one level below (i.e., 3-way interactions are constrained only based on the values of the 2-way interactions). This PR updates constraints to be based on the full probabilities (i.e., including main effects and other lower level interactions) to ensure monotonicity constraints for the LCDM are met.