### PR TITLE
updates to returned samples

### DIFF
--- a/R/add-model-evaluation.R
+++ b/R/add-model-evaluation.R
@@ -207,6 +207,8 @@ add_reliability <- function(x, overwrite = FALSE, save = TRUE, ...) {
 add_fit <- function(
   x,
   method = c("m2", "ppmc"),
+  ndraws = NULL,
+  return_draws = ndraws,
   overwrite = FALSE,
   save = TRUE,
   ...,
@@ -227,6 +229,26 @@ add_fit <- function(
     )
   }
 
+  total_draws <- posterior::ndraws(posterior::as_draws(x))
+  check_number_whole(
+    ndraws,
+    min = 1,
+    max = as.numeric(total_draws),
+    allow_null = TRUE
+  )
+  if (is.null(ndraws)) {
+    ndraws <- total_draws
+  }
+  check_number_whole(
+    return_draws,
+    min = 1,
+    max = as.numeric(ndraws),
+    allow_null = TRUE
+  )
+  if (is.null(return_draws)) {
+    return_draws <- ndraws
+  }
+
   resave <- FALSE
 
   # m2 -------------------------------------------------------------------------
@@ -237,7 +259,13 @@ add_fit <- function(
 
   # ppmc -----------------------------------------------------------------------
   if ("ppmc" %in% method) {
-    ppmc_list <- fit_ppmc(x, ..., force = overwrite)
+    ppmc_list <- fit_ppmc(
+      x,
+      ...,
+      ndraws = ndraws,
+      return_draws = return_draws,
+      force = overwrite
+    )
 
     if (!all(names(ppmc_list) %in% names(x@fit)) || overwrite) {
       resave <- TRUE

--- a/R/add-model-evaluation.R
+++ b/R/add-model-evaluation.R
@@ -9,6 +9,7 @@
 #' @inheritParams loo::loo
 #' @inheritParams dcm2::calc_m2
 #' @inheritParams score
+#' @inheritParams fit_ppmc
 #' @param x A [measrdcm][dcm_estimate()] object.
 #' @param criterion A vector of information criteria to calculate and add to the
 #'   model object. Must be `"loo"`, `"waic"`, or `"log_mll"` for models

--- a/R/zzz-methods-ppmc.R
+++ b/R/zzz-methods-ppmc.R
@@ -184,7 +184,24 @@ S7::method(fit_ppmc, measrdcm) <- function(
     return(list())
   } else if (!force) {
     all_ppmc <- paste0("ppmc_", all_ppmc)
-    results <- lapply(all_ppmc, \(pc) x@fit[[pc]]) |>
+    results <- lapply(
+      all_ppmc,
+      \(pc, return_draws) {
+        cur_pc <- x@fit[[pc]]
+        cur_pc <- if (is.null(cur_pc)) {
+          NULL
+        } else if (return_draws == 0) {
+          dplyr::select(cur_pc, -dplyr::matches("samples"))
+        } else {
+          cur_pc |>
+            dplyr::mutate(dplyr::across(dplyr::matches("samples"), \(x) {
+              lapply(x, sample_ppmc, n = return_draws)
+            }))
+        }
+        cur_pc
+      },
+      return_draws = return_draws
+    ) |>
       rlang::set_names(all_ppmc)
 
     if (!any(vapply(results, rlang::is_null, logical(1)))) return(results)
@@ -366,16 +383,22 @@ ppmc_raw_score <- function(spec, obs, post, probs, return_draws, ...) {
   if (return_draws > 0) {
     raw_score_res <- raw_score_res |>
       dplyr::mutate(
-        rawscore_samples = list(
-          raw_score_post |>
-            tidyr::nest(raw_scores = -".draw") |>
-            dplyr::slice_sample(n = return_draws) |>
-            dplyr::select(-".draw")
+        rawscore_samples = rlang::set_names(
+          list(
+            raw_score_post |>
+              tidyr::nest(raw_scores = -".draw") |>
+              dplyr::slice_sample(n = return_draws) |>
+              dplyr::select(-".draw")
+          ),
+          "rawscores"
         ),
-        chisq_samples = list(
-          chisq_ppmc |>
-            dplyr::slice_sample(n = return_draws) |>
-            dplyr::pull("chisq")
+        chisq_samples = rlang::set_names(
+          list(
+            chisq_ppmc |>
+              dplyr::slice_sample(n = return_draws) |>
+              dplyr::pull("chisq")
+          ),
+          "chisqs"
         ),
         .before = "ppp"
       )
@@ -500,11 +523,14 @@ ppmc_conditional_prob <- function(
   if (return_draws > 0) {
     cond_pval_res <- cond_pval_res |>
       dplyr::mutate(
-        samples = lapply(.data$cond_pval, function(.x) {
-          .x |>
-            dplyr::slice_sample(n = return_draws) |>
-            dplyr::pull("pi")
-        }),
+        samples = rlang::set_names(
+          lapply(.data$cond_pval, function(.x) {
+            .x |>
+              dplyr::slice_sample(n = return_draws) |>
+              dplyr::pull("pi")
+          }),
+          nm = glue::glue("{i}_{c}")
+        ),
         .before = "ppp"
       )
   }
@@ -572,11 +598,14 @@ ppmc_odds_ratio <- function(spec, obs, post, probs, return_draws, ...) {
     or_res <- or_res |>
       dplyr::relocate("samples", .before = "ppp") |>
       dplyr::mutate(
-        samples = lapply(.data$samples, function(.x) {
-          .x |>
-            dplyr::slice_sample(n = return_draws) |>
-            dplyr::pull("or")
-        })
+        samples = rlang::set_names(
+          lapply(.data$samples, function(.x) {
+            .x |>
+              dplyr::slice_sample(n = return_draws) |>
+              dplyr::pull("or")
+          }),
+          nm = glue::glue("{item_1}_{item_2}")
+        )
       )
   } else {
     or_res <- dplyr::select(or_res, -"samples")
@@ -630,11 +659,14 @@ ppmc_pvalue <- function(spec, obs, post, probs, return_draws, ...) {
     pval_res <- pval_res |>
       dplyr::relocate("samples", .before = "ppp") |>
       dplyr::mutate(
-        samples = lapply(.data$samples, function(x) {
-          x |>
-            dplyr::slice_sample(n = return_draws) |>
-            dplyr::pull("pvalue")
-        })
+        samples = rlang::set_names(
+          lapply(.data$samples, function(x) {
+            x |>
+              dplyr::slice_sample(n = return_draws) |>
+              dplyr::pull("pvalue")
+          }),
+          nm = glue::glue("{item}")
+        )
       )
   } else {
     pval_res <- dplyr::select(pval_res, -"samples")

--- a/R/zzz-methods-sample-ppmc.R
+++ b/R/zzz-methods-sample-ppmc.R
@@ -4,9 +4,11 @@ sample_ppmc <- S7::new_generic("sample_ppmc", "x", function(x, n, ...) {
 
 # methods-----------------------------------------------------------------------
 S7::method(sample_ppmc, S7::new_S3_class("tbl_df")) <- function(x, n) {
+  check_number_whole(n, min = 1, max = as.numeric(nrow(x)))
   dplyr::slice_sample(x, n = n)
 }
 
 S7::method(sample_ppmc, S7::new_S3_class("double")) <- function(x, n) {
+  check_number_whole(n, min = 1, max = as.numeric(length(x)))
   sample(x, size = n)
 }

--- a/R/zzz-methods-sample-ppmc.R
+++ b/R/zzz-methods-sample-ppmc.R
@@ -1,0 +1,12 @@
+sample_ppmc <- S7::new_generic("sample_ppmc", "x", function(x, n, ...) {
+  S7::S7_dispatch()
+})
+
+# methods-----------------------------------------------------------------------
+S7::method(sample_ppmc, S7::new_S3_class("tbl_df")) <- function(x, n) {
+  dplyr::slice_sample(x, n = n)
+}
+
+S7::method(sample_ppmc, S7::new_S3_class("double")) <- function(x, n) {
+  sample(x, size = n)
+}

--- a/man/model_evaluation.Rd
+++ b/man/model_evaluation.Rd
@@ -22,6 +22,8 @@ add_reliability(x, overwrite = FALSE, save = TRUE, ...)
 add_fit(
   x,
   method = c("m2", "ppmc"),
+  ndraws = NULL,
+  return_draws = ndraws,
   overwrite = FALSE,
   save = TRUE,
   ...,
@@ -78,6 +80,18 @@ functions for help computing \code{r_eff}.}
 
 \item{method}{A vector of model fit methods to evaluate and add to the model
 object.}
+
+\item{ndraws}{The number of posterior draws to base the checks on. Must be
+less than or equal to the total number of posterior draws retained in the
+estimated model. If \code{NULL} (the default) the total number from the
+estimated model is used.}
+
+\item{return_draws}{Number of posterior draws for each specified fit
+statistic to be returned. This does not affect the calculation of the
+posterior predictive checks, but can be useful for visualizing the fit
+statistics. Must be less than \code{ndraws} (or the total number of draws if
+\code{ndraws = NULL}). If \code{0} (the default), only summaries of the posterior are
+returned (no individual samples).}
 
 \item{ci}{The confidence interval for the RMSEA, computed from the M2}
 

--- a/tests/testthat/test-mcmc.R
+++ b/tests/testthat/test-mcmc.R
@@ -555,7 +555,10 @@ test_that("ppmc works", {
   )
   expect_equal(
     vapply(test_ppmc$ppmc_conditional_prob$samples, length, integer(1)),
-    rep(100, 8)
+    rlang::set_names(
+      rep(100, 8),
+      nm = paste0(rep(1:4, each = 2), "_", rep(1:2, times = 4))
+    )
   )
 
   # test 2 -----
@@ -592,7 +595,10 @@ test_that("ppmc works", {
   )
   expect_equal(
     vapply(test_ppmc$ppmc_odds_ratio$samples, length, integer(1)),
-    rep(180, 6)
+    rlang::set_names(
+      rep(180, 6),
+      c(paste0(1, "_", 2:4), paste0(2, "_", 3:4), "3_4")
+    )
   )
 
   expect_s3_class(test_ppmc$ppmc_pvalue, "tbl_df")
@@ -604,7 +610,7 @@ test_that("ppmc works", {
   expect_equal(as.character(test_ppmc$ppmc_pvalue$item), paste0("mdm", 1:4))
   expect_equal(
     vapply(test_ppmc$ppmc_pvalue$samples, length, double(1)),
-    rep(180, 4)
+    rlang::set_names(rep(180, 4), nm = paste0(1:4))
   )
 
   # test 3 -----
@@ -671,8 +677,8 @@ test_that("model fit can be added", {
     )
   )
   expect_identical(
-    test_model@fit[-which(names(test_model@fit) == "m2")],
-    fit_ppmc(test_model, item_fit = "odds_ratio")
+    dplyr::select(test_model@fit$ppmc_odds_ratio, -"samples"),
+    fit_ppmc(test_model, item_fit = "odds_ratio")$ppmc_odds_ratio
   )
 
   # nothing new does nothing -----
@@ -693,7 +699,15 @@ test_that("model fit can be added", {
   )
   expect_equal(
     names(test_model@fit$ppmc_raw_score),
-    c("obs_chisq", "ppmc_mean", "5.5%", "94.5%", "ppp")
+    c(
+      "obs_chisq",
+      "ppmc_mean",
+      "5.5%",
+      "94.5%",
+      "rawscore_samples",
+      "chisq_samples",
+      "ppp"
+    )
   )
   expect_equal(
     names(test_model@fit$ppmc_odds_ratio),
@@ -710,8 +724,21 @@ test_that("model fit can be added", {
   )
   expect_equal(
     names(test_model@fit$ppmc_conditional_prob),
-    c("item", "class", "obs_cond_pval", "ppmc_mean", "5.5%", "94.5%", "ppp")
+    c(
+      "item",
+      "class",
+      "obs_cond_pval",
+      "ppmc_mean",
+      "5.5%",
+      "94.5%",
+      "samples",
+      "ppp"
+    )
   )
+  expect_equal(length(test_model@fit$ppmc_odds_ratio$samples[[1]]), 100)
+  expect_equal(nrow(test_model@fit$ppmc_raw_score$rawscore_samples[[1]]), 1000)
+  expect_equal(length(test_model@fit$ppmc_raw_score$chisq_samples[[1]]), 1000)
+  expect_equal(length(test_model@fit$ppmc_conditional_prob$samples[[1]]), 1000)
 
   # now calculate conditional probs and overall pvalue - overall is new, -----
   # but conditional prob should use stored value
@@ -723,7 +750,7 @@ test_that("model fit can be added", {
   expect_equal(names(test_ppmc), c("ppmc_conditional_prob", "ppmc_pvalue"))
   expect_identical(
     test_ppmc$ppmc_conditional_prob,
-    test_model@fit$ppmc_conditional_prob
+    dplyr::select(test_model@fit$ppmc_conditional_prob, -"samples")
   )
   expect_equal(
     names(test_ppmc$ppmc_pvalue),
@@ -753,7 +780,15 @@ test_that("model fit can be added", {
   )
   expect_equal(
     names(test_model@fit$ppmc_raw_score),
-    c("obs_chisq", "ppmc_mean", "5.5%", "94.5%", "ppp")
+    c(
+      "obs_chisq",
+      "ppmc_mean",
+      "5.5%",
+      "94.5%",
+      "rawscore_samples",
+      "chisq_samples",
+      "ppp"
+    )
   )
   expect_equal(
     names(test_model@fit$ppmc_odds_ratio),
@@ -785,6 +820,11 @@ test_that("model fit can be added", {
     names(test_model@fit$ppmc_pvalue),
     c("item", "obs_pvalue", "ppmc_mean", "10%", "90%", "samples", "ppp")
   )
+  expect_equal(length(test_model@fit$ppmc_odds_ratio$samples[[1]]), 100)
+  expect_equal(nrow(test_model@fit$ppmc_raw_score$rawscore_samples[[1]]), 1000)
+  expect_equal(length(test_model@fit$ppmc_raw_score$chisq_samples[[1]]), 1000)
+  expect_equal(length(test_model@fit$ppmc_conditional_prob$samples[[1]]), 200)
+  expect_equal(length(test_model@fit$ppmc_pvalue$samples[[1]]), 200)
 
   # test extraction -----
   rs_check <- measr_extract(test_model, "ppmc_raw_score")

--- a/tests/testthat/test-mcmc.R
+++ b/tests/testthat/test-mcmc.R
@@ -682,7 +682,7 @@ test_that("model fit can be added", {
   )
 
   # nothing new does nothing -----
-  test_model2 <- add_fit(test_model, method = "ppmc")
+  test_model2 <- add_fit(test_model, method = "ppmc", return_draws = NULL)
   expect_identical(test_model, test_model2)
 
   # now add raw score and conditional probs -- other fit should persist -----
@@ -897,6 +897,58 @@ test_that("model fit can be added", {
   expect_equal(
     measr_extract(test_model, "ppmc_pvalue_flags", ppmc_interval = 0.6),
     dplyr::filter(pval_check, ppp <= 0.2 | ppp >= 0.8)
+  )
+
+  # fit ppmc can return draws -----
+  fit1 <- fit_ppmc(test_model, model_fit = "raw_score")
+  expect_equal(names(fit1), "ppmc_raw_score")
+  expect_equal(
+    names(fit1$ppmc_raw_score),
+    c("obs_chisq", "ppmc_mean", "5.5%", "94.5%", "ppp")
+  )
+
+  fit2 <- fit_ppmc(
+    test_model,
+    model_fit = "raw_score",
+    item_fit = "pvalue",
+    return_draws = 100
+  )
+  expect_equal(names(fit2), c("ppmc_raw_score", "ppmc_pvalue"))
+  expect_equal(
+    names(fit2$ppmc_raw_score),
+    c(
+      "obs_chisq",
+      "ppmc_mean",
+      "5.5%",
+      "94.5%",
+      "rawscore_samples",
+      "chisq_samples",
+      "ppp"
+    )
+  )
+  expect_equal(
+    names(fit2$ppmc_pvalue),
+    c(
+      "item",
+      "obs_pvalue",
+      "ppmc_mean",
+      "10%",
+      "90%",
+      "samples",
+      "ppp"
+    )
+  )
+  expect_equal(
+    vapply(fit2$ppmc_raw_score$rawscore_samples, nrow, integer(1)),
+    rlang::set_names(100, "rawscores")
+  )
+  expect_equal(
+    vapply(fit2$ppmc_raw_score$chisq_samples, length, integer(1)),
+    rlang::set_names(100, "chisqs")
+  )
+  expect_equal(
+    vapply(fit2$ppmc_pvalue$samples, length, integer(1)),
+    rlang::set_names(rep(100, 4), paste0(1:4))
   )
 })
 

--- a/tests/testthat/test-pathfinder.R
+++ b/tests/testthat/test-pathfinder.R
@@ -419,7 +419,10 @@ test_that("ppmc works", {
   )
   expect_equal(
     vapply(test_ppmc$ppmc_conditional_prob$samples, length, integer(1)),
-    rep(100, 162)
+    rlang::set_names(
+      rep(100, 162),
+      nm = paste0(rep(1:27, each = 6), "_", rep(1:6, times = 27))
+    )
   )
 
   # test 2 -----
@@ -461,9 +464,16 @@ test_that("ppmc works", {
     as.character(test_ppmc$ppmc_odds_ratio$item_2),
     names(lcdm_spec@qmatrix_meta$item_names[item_combos$item2])
   )
+  pair_names <- rlang::rep_along(1:26, list())
+  for (i in seq_along(pair_names)) {
+    pair_names[[i]] <- paste0(i, "_", (i + 1):27)
+  }
   expect_equal(
     vapply(test_ppmc$ppmc_odds_ratio$samples, length, integer(1)),
-    rep(180, 351)
+    rlang::set_names(
+      rep(180, 351),
+      unlist(pair_names)
+    )
   )
 
   expect_s3_class(test_ppmc$ppmc_pvalue, "tbl_df")
@@ -478,7 +488,7 @@ test_that("ppmc works", {
   )
   expect_equal(
     vapply(test_ppmc$ppmc_pvalue$samples, length, double(1)),
-    rep(180, 27)
+    rlang::set_names(rep(180, 27), nm = paste0(1:27))
   )
 
   # test 3 -----

--- a/tests/testthat/test-variational.R
+++ b/tests/testthat/test-variational.R
@@ -477,7 +477,10 @@ test_that("ppmc works", {
   )
   expect_equal(
     vapply(test_ppmc$ppmc_conditional_prob$samples, length, integer(1)),
-    rep(100, 8)
+    rlang::set_names(
+      rep(100, 8),
+      nm = paste0(rep(1:4, each = 2), "_", rep(1:2, times = 4))
+    )
   )
 
   # test 2 -----
@@ -514,7 +517,10 @@ test_that("ppmc works", {
   )
   expect_equal(
     vapply(test_ppmc$ppmc_odds_ratio$samples, length, integer(1)),
-    rep(180, 6)
+    rlang::set_names(
+      rep(180, 6),
+      c(paste0(1, "_", 2:4), paste0(2, "_", 3:4), "3_4")
+    )
   )
 
   expect_s3_class(test_ppmc$ppmc_pvalue, "tbl_df")
@@ -526,7 +532,7 @@ test_that("ppmc works", {
   expect_equal(as.character(test_ppmc$ppmc_pvalue$item), paste0("mdm", 1:4))
   expect_equal(
     vapply(test_ppmc$ppmc_pvalue$samples, length, double(1)),
-    rep(180, 4)
+    rlang::set_names(rep(180, 4), nm = paste0(1:4))
   )
 
   # test 3 -----
@@ -593,8 +599,8 @@ test_that("model fit can be added", {
     )
   )
   expect_identical(
-    test_model@fit[-which(names(test_model@fit) == "m2")],
-    fit_ppmc(test_model, item_fit = "odds_ratio")
+    dplyr::select(test_model@fit$ppmc_odds_ratio, -"samples"),
+    fit_ppmc(test_model, item_fit = "odds_ratio")$ppmc_odds_ratio
   )
 
   # nothing new does nothing -----
@@ -615,7 +621,15 @@ test_that("model fit can be added", {
   )
   expect_equal(
     names(test_model@fit$ppmc_raw_score),
-    c("obs_chisq", "ppmc_mean", "5.5%", "94.5%", "ppp")
+    c(
+      "obs_chisq",
+      "ppmc_mean",
+      "5.5%",
+      "94.5%",
+      "rawscore_samples",
+      "chisq_samples",
+      "ppp"
+    )
   )
   expect_equal(
     names(test_model@fit$ppmc_odds_ratio),
@@ -632,8 +646,21 @@ test_that("model fit can be added", {
   )
   expect_equal(
     names(test_model@fit$ppmc_conditional_prob),
-    c("item", "class", "obs_cond_pval", "ppmc_mean", "5.5%", "94.5%", "ppp")
+    c(
+      "item",
+      "class",
+      "obs_cond_pval",
+      "ppmc_mean",
+      "5.5%",
+      "94.5%",
+      "samples",
+      "ppp"
+    )
   )
+  expect_equal(length(test_model@fit$ppmc_odds_ratio$samples[[1]]), 100)
+  expect_equal(nrow(test_model@fit$ppmc_raw_score$rawscore_samples[[1]]), 2000)
+  expect_equal(length(test_model@fit$ppmc_raw_score$chisq_samples[[1]]), 2000)
+  expect_equal(length(test_model@fit$ppmc_conditional_prob$samples[[1]]), 2000)
 
   # now calculate conditional probs and overall pvalue - overall is new, -----
   # but conditional prob should use stored value
@@ -645,7 +672,7 @@ test_that("model fit can be added", {
   expect_equal(names(test_ppmc), c("ppmc_conditional_prob", "ppmc_pvalue"))
   expect_identical(
     test_ppmc$ppmc_conditional_prob,
-    test_model@fit$ppmc_conditional_prob
+    dplyr::select(test_model@fit$ppmc_conditional_prob, -"samples")
   )
   expect_equal(
     names(test_ppmc$ppmc_pvalue),
@@ -675,7 +702,15 @@ test_that("model fit can be added", {
   )
   expect_equal(
     names(test_model@fit$ppmc_raw_score),
-    c("obs_chisq", "ppmc_mean", "5.5%", "94.5%", "ppp")
+    c(
+      "obs_chisq",
+      "ppmc_mean",
+      "5.5%",
+      "94.5%",
+      "rawscore_samples",
+      "chisq_samples",
+      "ppp"
+    )
   )
   expect_equal(
     names(test_model@fit$ppmc_odds_ratio),
@@ -707,6 +742,11 @@ test_that("model fit can be added", {
     names(test_model@fit$ppmc_pvalue),
     c("item", "obs_pvalue", "ppmc_mean", "10%", "90%", "samples", "ppp")
   )
+  expect_equal(length(test_model@fit$ppmc_odds_ratio$samples[[1]]), 100)
+  expect_equal(nrow(test_model@fit$ppmc_raw_score$rawscore_samples[[1]]), 2000)
+  expect_equal(length(test_model@fit$ppmc_raw_score$chisq_samples[[1]]), 2000)
+  expect_equal(length(test_model@fit$ppmc_conditional_prob$samples[[1]]), 200)
+  expect_equal(length(test_model@fit$ppmc_pvalue$samples[[1]]), 200)
 
   # test extraction -----
   rs_check <- measr_extract(test_model, "ppmc_raw_score")

--- a/tests/testthat/test-zzz-methods-sample-ppmc.R
+++ b/tests/testthat/test-zzz-methods-sample-ppmc.R
@@ -1,0 +1,28 @@
+test_that("sampling tibble works", {
+  expect_equal(nrow(sample_ppmc(dcmdata::ecpe_qmatrix, n = 10)), 10L)
+  expect_equal(nrow(sample_ppmc(dcmdata::mdm_data, n = 100)), 100L)
+
+  expect_error(
+    sample_ppmc(dcmdata::dtmr_qmatrix, n = 30),
+    "whole number between 1 and 27"
+  )
+})
+
+test_that("sampling vector works", {
+  expect_equal(length(sample_ppmc(rnorm(100), n = 10)), 10L)
+  expect_equal(length(sample_ppmc(runif(1000), n = 100)), 100L)
+
+  expect_error(
+    sample_ppmc(rbeta(20, 5, 17), n = 30),
+    "whole number between 1 and 20"
+  )
+})
+
+test_that("unknown class errors", {
+  expect_error(sample_ppmc(1:5, n = 2), "Can't find method")
+  expect_error(sample_ppmc(letters, n = 10), "Can't find method")
+  expect_error(
+    sample_ppmc(vector(mode = "logical", length = 60), n = 15),
+    "Can't find method"
+  )
+})


### PR DESCRIPTION
Closes #83.

Samples are saved by default with `add_model_fit()`, then optionally returned with `fit_ppmc()` based on `return_draws`.